### PR TITLE
Support new Roc compiler's `roc bundle` CLI

### DIFF
--- a/.github/workflows/run-self.yaml
+++ b/.github/workflows/run-self.yaml
@@ -14,27 +14,55 @@ on:
 
 jobs:
   run-self:
-    name: Run self
+    name: Run self (${{ matrix.cli }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cli: legacy
+            roc-version: alpha4-rolling
+            example-repo: Hasnep/roc-html
+            checkout-path: roc-html
+            library: roc-html/src/main.roc
+            expected-extension-regex: "\\.tar\\.br$"
+          - cli: new
+            roc-version: nightly-new-compiler
+            example-repo: imclerran/rtils
+            checkout-path: rtils
+            library: rtils/package/main.roc
+            expected-extension-regex: "\\.tar\\.zst$"
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
       - name: Checkout an example repo
         uses: actions/checkout@v3
         with:
-          repository: Hasnep/roc-html
-          path: roc-html
+          repository: ${{ matrix.example-repo }}
+          path: ${{ matrix.checkout-path }}
       - name: Install Roc
-        uses: Hasnep/setup-roc@main
+        uses: roc-lang/setup-roc@main
         with:
-          roc-version: nightly
-          token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ matrix.roc-version }}
       - name: Run the action
         id: bundle-library
         uses: ./
         with:
-          library: roc-html/src/main.roc
+          library: ${{ matrix.library }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check bundled library exists
+      - name: Check bundled library exists and has the correct extension
+        env:
+          BUNDLE_PATH: ${{ steps.bundle-library.outputs.bundle-path }}
         run: |
-          test -f "${{ steps.bundle-library.outputs.bundle-path }}"
+          if $(test -f "$BUNDLE_PATH"); then \
+            echo "$BUNDLE_PATH exists."
+          else
+            echo "::error::Expected $BUNDLE_PATH to exist."
+            exit 1
+          fi
+          if [[ $BUNDLE_PATH =~ ${{ matrix.expected-extension-regex }} ]]; then \
+            echo "$BUNDLE_PATH matches the expected extension ${{ matrix.expected-extension-regex }}."
+          else
+            echo "::error::Expected extension to match ${{ matrix.expected-extension-regex }}, got $BUNDLE_PATH"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 A GitHub Action to bundle and release a Roc library.
 
+The action works with both the legacy Roc compiler (which exposes
+`roc build --bundle`) and the new Roc compiler (which exposes `roc bundle`).
+The CLI is autodetected at runtime by probing for the `roc bundle`
+subcommand — no configuration is required.
+
+## Inputs
+
+- `library` (required)
+  - Path to the library's entrypoint file.
+- `roc-path` (optional)
+  - Path to the Roc executable. Defaults to `roc`.
+- `bundle-type` (optional)
+  - Legacy CLI only. One of `.tar`, `.tar.gz`, `.tar.br`. Ignored with a warning on the new CLI, which always produces `.tar.zst`. Defaults to `.tar.br`.
+- `compression` (optional)
+  - New CLI only. zstd compression level (1–22). Ignored with a warning on the legacy CLI. If unset, the compiler's default is used.
+- `release` (optional)
+  - Whether to upload the bundle to the repository's releases. Defaults to `true` on release events, otherwise `false`.
+- `tag` (optional)
+  - Tag of the release to upload to. Defaults to the current Git tag.
+- `token` (optional)
+  - GitHub token used to upload the release asset. Defaults to the token provided by GitHub Actions.
+
+## Outputs
+
+- `bundle-path`
+  - The absolute path to the bundled library.
+
 ## Usage
 
 ```yaml
@@ -23,9 +50,9 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v3
       - name: Install Roc
-        uses: hasnep/setup-roc@main
+        uses: roc-lang/setup-roc@main
         with:
-          roc-version: nightly
+          version: nightly-new-compiler # or e.g. alpha4-rolling for the legacy compiler
       - name: Bundle and release the library
         uses: hasnep/bundle-roc-library@main
         with:

--- a/action.yaml
+++ b/action.yaml
@@ -10,9 +10,10 @@ inputs:
     required: true
     default: roc
   bundle-type:
-    description: The filetype of the bundled library, either `.tar`, `.tar.gz` or `.tar.br`. Defaults to `.tar.br`.
-    required: true
+    description: The filetype of the bundled library, either `.tar`, `.tar.gz` or `.tar.br`. Only applies to the legacy Roc CLI; ignored (with a warning) on the new `roc bundle` CLI, which always produces `.tar.zst`. Defaults to `.tar.br`.
     default: .tar.br
+  compression:
+    description: zstd compression level (1–22) for the new `roc bundle` CLI. Ignored (with a warning) on the legacy CLI. If unset, the compiler's default is used.
   release:
     description: Whether or not the bundled library should be uploaded to the repository's releases. Defaults to only uploading when the action is triggered by a release event.
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -9632,7 +9632,38 @@ const core = __nccwpck_require__(2186);
 const fs = __nccwpck_require__(7147);
 const gh = __nccwpck_require__(5438);
 const path = __nccwpck_require__(1017);
-const bundleLibrary = (rocPath, libraryEntrypointPath, bundleType) => {
+const detectCli = (rocPath) => {
+    // The legacy compiler prints global help (exit 0) for unknown subcommands, so an exit code alone can't distinguish CLIs.
+    // Match on a flag name unique to the new `roc bundle` subcommand.
+    try {
+        const out = (0, child_process_1.execSync)(`${quoteIfSpaces(rocPath)} bundle --help`, {
+            stdio: ["ignore", "pipe", "ignore"],
+        }).toString();
+        return out.includes("--output-dir") ? "new" : "legacy";
+    }
+    catch (_a) {
+        return "legacy";
+    }
+};
+const quoteIfSpaces = (x) => (x.includes(" ") ? `"${x}"` : x);
+const findRocFiles = (dir) => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...findRocFiles(full));
+        }
+        else if (entry.name.endsWith(".roc")) {
+            files.push(full);
+        }
+    }
+    return files;
+};
+const bundleLibraryLegacy = (rocPath, libraryEntrypointPath, bundleType, compression) => {
+    if (compression !== "") {
+        core.warning("Ignoring 'compression' input on legacy Roc CLI.");
+    }
     const bundleCommand = [
         rocPath,
         "build",
@@ -9640,20 +9671,45 @@ const bundleLibrary = (rocPath, libraryEntrypointPath, bundleType) => {
         bundleType,
         libraryEntrypointPath,
     ]
-        .map((x) => (x.includes(" ") ? `"${x}"` : x)) // Add quotes to paths that contain spaces
+        .map(quoteIfSpaces)
         .join(" ");
     core.info(`Running bundle command '${bundleCommand}'.`);
     const stdOut = (0, child_process_1.execSync)(bundleCommand);
     core.info(stdOut.toString());
 };
-const getBundlePath = (libraryEntrypointPath, bundleType) => __awaiter(void 0, void 0, void 0, function* () {
+const bundleLibraryNew = (rocPath, libraryEntrypointPath, bundleType, compression) => {
+    if (bundleType !== ".tar.zst") {
+        core.warning("Ignoring 'bundle-type' input on new Roc CLI; bundles are always '.tar.zst'.");
+    }
+    // The new `roc bundle` does not auto-resolve imports — every source file
+    // must be passed on the command line. It also rejects absolute paths and
+    // paths containing `..` (roc-lang/roc#9406). Run it with cwd set to the
+    // entry's directory and pass every source as a path relative to that
+    // directory; output goes to `.` (the same directory).
+    const entryDir = path.resolve(path.dirname(libraryEntrypointPath));
+    const sourceFiles = findRocFiles(entryDir).map((f) => path.relative(entryDir, f));
+    const bundleCommand = [
+        rocPath,
+        "bundle",
+        "--output-dir",
+        ".",
+        ...(compression !== "" ? ["--compression", compression] : []),
+        ...sourceFiles,
+    ]
+        .map(quoteIfSpaces)
+        .join(" ");
+    core.info(`Running bundle command '${bundleCommand}' in '${entryDir}'.`);
+    const stdOut = (0, child_process_1.execSync)(bundleCommand, { cwd: entryDir });
+    core.info(stdOut.toString());
+};
+const getBundlePath = (libraryEntrypointPath, extension) => __awaiter(void 0, void 0, void 0, function* () {
     const libraryFolder = path.dirname(libraryEntrypointPath);
-    core.info(`Looking for bundled library in '${libraryFolder}' with extension '${bundleType}'.`);
+    core.info(`Looking for bundled library in '${libraryFolder}' with extension '${extension}'.`);
     const bundleFileName = fs
         .readdirSync(libraryFolder)
-        .find((x) => x.endsWith(bundleType));
+        .find((x) => x.endsWith(extension));
     if (bundleFileName === undefined) {
-        throw new Error(`Couldn't find bundled library in '${libraryFolder}' with extension '${bundleType}'.`);
+        throw new Error(`Couldn't find bundled library in '${libraryFolder}' with extension '${extension}'.`);
     }
     const bundlePath = path.resolve(path.join(libraryFolder, bundleFileName));
     core.info(`Found bundled library at '${bundlePath}'.`);
@@ -9687,7 +9743,8 @@ const main = () => __awaiter(void 0, void 0, void 0, function* () {
         // Get inputs
         const isRequired = { required: true };
         const token = core.getInput("token");
-        const bundleType = core.getInput("bundle-type", isRequired);
+        const bundleType = core.getInput("bundle-type");
+        const compression = core.getInput("compression");
         const libraryEntrypointPath = core.getInput("library", isRequired);
         const release = core.getBooleanInput("release", isRequired);
         const releaseTag = core
@@ -9695,9 +9752,18 @@ const main = () => __awaiter(void 0, void 0, void 0, function* () {
             .replace(/^refs\/(?:tags|heads)\//, "");
         const rocPath = core.getInput("roc-path", isRequired);
         const octokitClient = gh.getOctokit(token);
+        // Detect which Roc CLI we're talking to
+        const cli = detectCli(rocPath);
+        core.info(`Detected ${cli} Roc CLI.`);
         // Bundle the library
-        bundleLibrary(rocPath, libraryEntrypointPath, bundleType);
-        const bundlePath = yield getBundlePath(libraryEntrypointPath, bundleType);
+        if (cli === "new") {
+            bundleLibraryNew(rocPath, libraryEntrypointPath, bundleType, compression);
+        }
+        else {
+            bundleLibraryLegacy(rocPath, libraryEntrypointPath, bundleType, compression);
+        }
+        const expectedExtension = cli === "new" ? ".tar.zst" : bundleType;
+        const bundlePath = yield getBundlePath(libraryEntrypointPath, expectedExtension);
         core.setOutput("bundle-path", bundlePath);
         // Publish the bundle
         if (release) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,48 @@ import * as gh from "@actions/github";
 import * as path from "path";
 
 type Octokit = ReturnType<typeof gh.getOctokit>;
-type BundleType = ".tar" | ".tar.gz" | ".tar.br";
+type LegacyBundleType = ".tar" | ".tar.gz" | ".tar.br";
+type BundleType = LegacyBundleType | ".tar.zst";
+type CliVersion = "legacy" | "new";
 
-const bundleLibrary = (
+const detectCli = (rocPath: string): CliVersion => {
+  // The legacy compiler prints global help (exit 0) for unknown subcommands, so an exit code alone can't distinguish CLIs.
+  // Match on a flag name unique to the new `roc bundle` subcommand.
+  try {
+    const out = execSync(`${quoteIfSpaces(rocPath)} bundle --help`, {
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    return out.includes("--output-dir") ? "new" : "legacy";
+  } catch {
+    return "legacy";
+  }
+};
+
+const quoteIfSpaces = (x: string): string => (x.includes(" ") ? `"${x}"` : x);
+
+const findRocFiles = (dir: string): string[] => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findRocFiles(full));
+    } else if (entry.name.endsWith(".roc")) {
+      files.push(full);
+    }
+  }
+  return files;
+};
+
+const bundleLibraryLegacy = (
   rocPath: string,
   libraryEntrypointPath: string,
-  bundleType: BundleType,
+  bundleType: LegacyBundleType,
+  compression: string,
 ) => {
+  if (compression !== "") {
+    core.warning("Ignoring 'compression' input on legacy Roc CLI.");
+  }
   const bundleCommand = [
     rocPath,
     "build",
@@ -19,27 +54,62 @@ const bundleLibrary = (
     bundleType,
     libraryEntrypointPath,
   ]
-    .map((x) => (x.includes(" ") ? `"${x}"` : x)) // Add quotes to paths that contain spaces
+    .map(quoteIfSpaces)
     .join(" ");
   core.info(`Running bundle command '${bundleCommand}'.`);
   const stdOut = execSync(bundleCommand);
   core.info(stdOut.toString());
 };
 
-const getBundlePath = async (
+const bundleLibraryNew = (
+  rocPath: string,
   libraryEntrypointPath: string,
   bundleType: BundleType,
+  compression: string,
+) => {
+  if (bundleType !== ".tar.zst") {
+    core.warning(
+      "Ignoring 'bundle-type' input on new Roc CLI; bundles are always '.tar.zst'.",
+    );
+  }
+  // The new `roc bundle` does not auto-resolve imports — every source file
+  // must be passed on the command line. It also rejects absolute paths and
+  // paths containing `..` (roc-lang/roc#9406). Run it with cwd set to the
+  // entry's directory and pass every source as a path relative to that
+  // directory; output goes to `.` (the same directory).
+  const entryDir = path.resolve(path.dirname(libraryEntrypointPath));
+  const sourceFiles = findRocFiles(entryDir).map((f) =>
+    path.relative(entryDir, f),
+  );
+  const bundleCommand = [
+    rocPath,
+    "bundle",
+    "--output-dir",
+    ".",
+    ...(compression !== "" ? ["--compression", compression] : []),
+    ...sourceFiles,
+  ]
+    .map(quoteIfSpaces)
+    .join(" ");
+  core.info(`Running bundle command '${bundleCommand}' in '${entryDir}'.`);
+  const stdOut = execSync(bundleCommand, { cwd: entryDir });
+  core.info(stdOut.toString());
+};
+
+const getBundlePath = async (
+  libraryEntrypointPath: string,
+  extension: BundleType,
 ): Promise<string> => {
   const libraryFolder = path.dirname(libraryEntrypointPath);
   core.info(
-    `Looking for bundled library in '${libraryFolder}' with extension '${bundleType}'.`,
+    `Looking for bundled library in '${libraryFolder}' with extension '${extension}'.`,
   );
   const bundleFileName = fs
     .readdirSync(libraryFolder)
-    .find((x) => x.endsWith(bundleType));
+    .find((x) => x.endsWith(extension));
   if (bundleFileName === undefined) {
     throw new Error(
-      `Couldn't find bundled library in '${libraryFolder}' with extension '${bundleType}'.`,
+      `Couldn't find bundled library in '${libraryFolder}' with extension '${extension}'.`,
     );
   }
   const bundlePath = path.resolve(path.join(libraryFolder, bundleFileName));
@@ -91,7 +161,8 @@ const main = async () => {
     // Get inputs
     const isRequired = { required: true };
     const token = core.getInput("token");
-    const bundleType = core.getInput("bundle-type", isRequired) as BundleType;
+    const bundleType = core.getInput("bundle-type") as LegacyBundleType;
+    const compression = core.getInput("compression");
     const libraryEntrypointPath = core.getInput("library", isRequired);
     const release = core.getBooleanInput("release", isRequired);
     const releaseTag = core
@@ -100,9 +171,27 @@ const main = async () => {
     const rocPath = core.getInput("roc-path", isRequired);
     const octokitClient = gh.getOctokit(token);
 
+    // Detect which Roc CLI we're talking to
+    const cli = detectCli(rocPath);
+    core.info(`Detected ${cli} Roc CLI.`);
+
     // Bundle the library
-    bundleLibrary(rocPath, libraryEntrypointPath, bundleType);
-    const bundlePath = await getBundlePath(libraryEntrypointPath, bundleType);
+    if (cli === "new") {
+      bundleLibraryNew(rocPath, libraryEntrypointPath, bundleType, compression);
+    } else {
+      bundleLibraryLegacy(
+        rocPath,
+        libraryEntrypointPath,
+        bundleType,
+        compression,
+      );
+    }
+
+    const expectedExtension = cli === "new" ? ".tar.zst" : bundleType;
+    const bundlePath = await getBundlePath(
+      libraryEntrypointPath,
+      expectedExtension,
+    );
     core.setOutput("bundle-path", bundlePath);
 
     // Publish the bundle


### PR DESCRIPTION
## Summary

Adds transparent support for the new Roc compiler's `roc bundle` subcommand alongside the legacy `roc build --bundle` flow. The CLI is autodetected at runtime; existing consumers need no yaml change. A new optional `compression` input plumbs zstd levels through to the new CLI.

## What changed

- **CLI autodetection** — `detectCli()` probes `roc bundle --help` and looks for the `--output-dir` flag in the output. (An exit-code-only probe doesn't work because the legacy compiler exits 0 on unknown subcommands and shows global help.)
- **Dispatch** — `bundleLibraryLegacy` retains the original `roc build --bundle <type> <entry>` behaviour. `bundleLibraryNew` runs `roc bundle --output-dir . <basenames>` from the entry's directory (the new CLI rejects absolute paths and `..` segments — see roc-lang/roc#9406) and passes every `.roc` file found by a recursive walk (the new CLI does not auto-resolve imports).
- **New `compression` input** — optional, zstd level 1–22, forwarded to `--compression` on the new CLI; warn-and-ignored on the legacy CLI.
- **`bundle-type` is now optional** — same default (`.tar.br`); on the new CLI a non-default value is warn-and-ignored (the new CLI only produces `.tar.zst`).
- **Self-test matrix** — `.github/workflows/run-self.yaml` now covers both CLIs via `roc-lang/setup-roc` (`alpha4-rolling` against `Hasnep/roc-html`, `nightly-new-compiler` against `imclerran/rtils`), asserting the bundle exists with the expected extension for each leg.
- **README** updated to document the new input and CLI-specific behaviour.

## Notes

- The action's runtime is still `node16` per the existing `action.yaml`. Bumping to `node20` is a separate concern (GitHub deprecated `node16` runners) — happy to follow up in a separate PR if useful.
