### PR TITLE
Drop workarounds for fixed roc bundle bugs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9646,20 +9646,6 @@ const detectCli = (rocPath) => {
     }
 };
 const quoteIfSpaces = (x) => (x.includes(" ") ? `"${x}"` : x);
-const findRocFiles = (dir) => {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
-    const files = [];
-    for (const entry of entries) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-            files.push(...findRocFiles(full));
-        }
-        else if (entry.name.endsWith(".roc")) {
-            files.push(full);
-        }
-    }
-    return files;
-};
 const bundleLibraryLegacy = (rocPath, libraryEntrypointPath, bundleType, compression) => {
     if (compression !== "") {
         core.warning("Ignoring 'compression' input on legacy Roc CLI.");
@@ -9681,25 +9667,19 @@ const bundleLibraryNew = (rocPath, libraryEntrypointPath, bundleType, compressio
     if (bundleType !== ".tar.zst") {
         core.warning("Ignoring 'bundle-type' input on new Roc CLI; bundles are always '.tar.zst'.");
     }
-    // The new `roc bundle` does not auto-resolve imports — every source file
-    // must be passed on the command line. It also rejects absolute paths and
-    // paths containing `..` (roc-lang/roc#9406). Run it with cwd set to the
-    // entry's directory and pass every source as a path relative to that
-    // directory; output goes to `.` (the same directory).
-    const entryDir = path.resolve(path.dirname(libraryEntrypointPath));
-    const sourceFiles = findRocFiles(entryDir).map((f) => path.relative(entryDir, f));
+    const outputDir = path.dirname(libraryEntrypointPath);
     const bundleCommand = [
         rocPath,
         "bundle",
         "--output-dir",
-        ".",
+        outputDir,
         ...(compression !== "" ? ["--compression", compression] : []),
-        ...sourceFiles,
+        libraryEntrypointPath,
     ]
         .map(quoteIfSpaces)
         .join(" ");
-    core.info(`Running bundle command '${bundleCommand}' in '${entryDir}'.`);
-    const stdOut = (0, child_process_1.execSync)(bundleCommand, { cwd: entryDir });
+    core.info(`Running bundle command '${bundleCommand}'.`);
+    const stdOut = (0, child_process_1.execSync)(bundleCommand);
     core.info(stdOut.toString());
 };
 const getBundlePath = (libraryEntrypointPath, extension) => __awaiter(void 0, void 0, void 0, function* () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,20 +24,6 @@ const detectCli = (rocPath: string): CliVersion => {
 
 const quoteIfSpaces = (x: string): string => (x.includes(" ") ? `"${x}"` : x);
 
-const findRocFiles = (dir: string): string[] => {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  const files: string[] = [];
-  for (const entry of entries) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...findRocFiles(full));
-    } else if (entry.name.endsWith(".roc")) {
-      files.push(full);
-    }
-  }
-  return files;
-};
-
 const bundleLibraryLegacy = (
   rocPath: string,
   libraryEntrypointPath: string,
@@ -72,27 +58,19 @@ const bundleLibraryNew = (
       "Ignoring 'bundle-type' input on new Roc CLI; bundles are always '.tar.zst'.",
     );
   }
-  // The new `roc bundle` does not auto-resolve imports — every source file
-  // must be passed on the command line. It also rejects absolute paths and
-  // paths containing `..` (roc-lang/roc#9406). Run it with cwd set to the
-  // entry's directory and pass every source as a path relative to that
-  // directory; output goes to `.` (the same directory).
-  const entryDir = path.resolve(path.dirname(libraryEntrypointPath));
-  const sourceFiles = findRocFiles(entryDir).map((f) =>
-    path.relative(entryDir, f),
-  );
+  const outputDir = path.dirname(libraryEntrypointPath);
   const bundleCommand = [
     rocPath,
     "bundle",
     "--output-dir",
-    ".",
+    outputDir,
     ...(compression !== "" ? ["--compression", compression] : []),
-    ...sourceFiles,
+    libraryEntrypointPath,
   ]
     .map(quoteIfSpaces)
     .join(" ");
-  core.info(`Running bundle command '${bundleCommand}' in '${entryDir}'.`);
-  const stdOut = execSync(bundleCommand, { cwd: entryDir });
+  core.info(`Running bundle command '${bundleCommand}'.`);
+  const stdOut = execSync(bundleCommand);
   core.info(stdOut.toString());
 };
 


### PR DESCRIPTION
- `roc bundle` now accepts absolute paths, so the action no longer needs to set `cwd` to the entry's directory and pass relative paths with `--output-dir .`. Passes the entry's directory directly as `--output-dir` instead.
- `roc bundle` now auto-resolves imports, so the action no longer needs to recursively glob every `.roc` file under the entry's directory and pass them on the command line. Passes just the entrypoint instead. Removes the unused `findRocFiles` helper.
